### PR TITLE
Correcting HtmlWebpackPlugin option name.

### DIFF
--- a/src/plugin.js
+++ b/src/plugin.js
@@ -48,7 +48,7 @@ class MultipageWebpackPlugin {
     entriesToCreateTemplatesFor.forEach((entryKey) => {
       let htmlWebpackPluginOptions = {
         filename: this.getFullTemplatePath(entryKey),
-        chunkSortMode: 'dependency',
+        chunksSortMode: 'dependency',
         chunks: ['inline', this.vendorChunkName, entryKey, this.sharedChunkName]
       };
 


### PR DESCRIPTION
The used `chunkSortMode` option should have been `chunksSortMode` (note the extra `s`).  Without this, `HtmlWebpackPlugin` may include the common chunks in an unusable order (as repeatedly suggested [here](https://github.com/webpack/webpack/issues/959)).